### PR TITLE
supporting API keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ Alooma.py lets you programmatically perform all the basics of operating the Aloo
   import alooma
   api = alooma.Client(username="<YOUR_USERNAME>", password="<YOUR_PASSWORD>")
 
+  # If you have an API key, you may use it instead of your username and password
+  # by specifying it in the constructor:
+  api = alooma.Client(api_key="<YOUR_API_KEY>")
+
   # If you have more than one Alooma instance, you can choose the instance you want to
   # log into by specifying it in the constructor:
   api = alooma.Client(username="<YOUR_USERNAME>", password="<YOUR_PASSWORD>",


### PR DESCRIPTION
after adding support for API keys in app-alooma (https://github.com/Aloomaio/app-alooma/pull/656), we now update alooma-python to support usage of API keys.

now the Client may be instantiated using a new optional parameter, api_key.
if this parameter is provided, it will always be used in all requests' authorization header instead of performing a POST request to the login endpoint and saving the resulting cookie.

this is as unintrusive as possible in order to maintain backwards compatibility.

requires app-alooma's API key feature in order to work