### PR TITLE
Add table Management Functions

### DIFF
--- a/alooma/alooma.py
+++ b/alooma/alooma.py
@@ -838,7 +838,8 @@ class Client(object):
         url = self.rest_url + endpoints.CREATE_TABLE.format(schema=schema,
                                                             table=table_name)
         res = self._Client__send_request(requests.delete, url)
-
+        res.raise_for_status()
+        
         return res
 
     def alter_table(self, table_name, columns):

--- a/alooma/endpoints.py
+++ b/alooma/endpoints.py
@@ -1,0 +1,4 @@
+# Outputs
+CREATE_TABLE = 'tables/{schema}/{table}'
+DEFAULT_OUTPUT = 'outputs/default'
+OUTPUT = 'outputs/{output_id}'


### PR DESCRIPTION
Function to pull the table schema:
`api.get_table_schema(schema, table_name)`

Function to drop a table:
`api.drop_table(schema, table_name)`

Function to create a table from a mapping (for easy table re-creation or manual mapping)
`api.create_table_from_mapping(mapping, schema, table_name, dist_keys=[], sort_keys=[])`
