### PR TITLE
Custom Query Endpoint

### DIFF
--- a/alooma/alooma.py
+++ b/alooma/alooma.py
@@ -1343,12 +1343,15 @@ class Client(object):
 
         # Prep Data for Consolidation Post
         data = {
-            "custom_query": query,
-            "event_type": event_type,
-            "frequency": frequency,
-            "run_at": run_at,
-            "deployment_name": self.get_zk_deployment_name()
+        "custom_query": query,
+        "event_type": event_type,
+        "deployment_name": self.get_zk_deployment_name(),
+        "avoid_duplicates": False
         }
+        if frequency:
+            data["frequency"] = frequency
+        else:
+            data["run_at"] = run_at
 
         return self.__send_request(requests.post,
                                    scheduled_query_url,

--- a/alooma/alooma.py
+++ b/alooma/alooma.py
@@ -143,7 +143,7 @@ class Client(object):
 
     def get_zk_deployment_name(self):
         return self.get_deployment_info()['deploymentName']
-    
+
     def get_plumbing(self):
         """
         DEPRECATED - use get_structure() instead.

--- a/alooma/alooma.py
+++ b/alooma/alooma.py
@@ -141,9 +141,6 @@ class Client(object):
         res = self.__send_request(requests.get, url)
         return res.json().get('config_clientName')
 
-    def get_zk_deployment_name(self):
-        return self.get_deployment_info()['deploymentName']
-
     def get_plumbing(self):
         """
         DEPRECATED - use get_structure() instead.
@@ -1332,10 +1329,9 @@ class Client(object):
 
         # Prep Data for Consolidation Post
         data = {
-        "custom_query": query,
-        "event_type": event_type,
-        "deployment_name": self.get_zk_deployment_name(),
-        "avoid_duplicates": False
+            "custom_query": query,
+            "event_type": event_type,
+            "avoid_duplicates": False
         }
         if frequency:
             data["frequency"] = frequency

--- a/alooma/alooma.py
+++ b/alooma/alooma.py
@@ -60,6 +60,7 @@ DEFAULT_TIMEOUT = 60
 MAPPING_TIMEOUT = 300
 
 BASE_URL = 'https://app.alooma.com'
+CUSTOM_CONSOLIDATION_V2 = 'v2/consolidation/custom'
 
 
 class FailedToCreateInputException(Exception):
@@ -139,6 +140,9 @@ class Client(object):
         url = self.rest_url + 'repository'
         res = self.__send_request(requests.get, url)
         return res.json().get('config_clientName')
+
+    def get_zk_deployment_name(self):
+        return self.get_deployment_info()['deploymentName']
 
     def get_config(self):
         """
@@ -1335,14 +1339,15 @@ class Client(object):
         if event_type is None:
             raise Exception('Event type must be provided')
 
-        scheduled_query_url = self.rest_url + 'custom-consolidation'
+        scheduled_query_url = self.rest_url + CUSTOM_CONSOLIDATION_V2
 
         # Prep Data for Consolidation Post
         data = {
             "custom_query": query,
             "event_type": event_type,
             "frequency": frequency,
-            "run_at": run_at
+            "run_at": run_at,
+            "deployment_name": self.get_zk_deployment_name()
         }
 
         return self.__send_request(requests.post,


### PR DESCRIPTION
Adding support for schedule_query via the new v2/consolidation endpoint.  

The endpoint accepts the same options as the old endpoint except that it currently requires the zk deployment name to be submitted