### PR TITLE
Only Get Account Name When not Specified

### DIFF
--- a/alooma/alooma.py
+++ b/alooma/alooma.py
@@ -98,7 +98,7 @@ class Client(object):
             headers = {"authorization": "API " + self.api_key}
             self.requests_params["headers"] = headers
 
-        self.account_name = self.__get_account_name()
+        self.account_name = account_name or self.__get_account_name()
 
     def __send_request(self, func, url, is_recheck=False, **kwargs):
         params = self.requests_params.copy()


### PR DESCRIPTION
Currently we call __get_account_name with every login.  The endpoint is failing quite often but this is not needed except when account name is not specified