### PR TITLE
Add TimeoutError in __send_request

### DIFF
--- a/alooma/alooma.py
+++ b/alooma/alooma.py
@@ -120,7 +120,7 @@ class Client(object):
             return self.__send_request(func, url, True, **kwargs)
 
         if response.status_code == 504:
-            raise TimeoutError(f"The rest call to {url} failed due to timing out after {params.get("timeout")}s")
+            raise TimeoutError(f"The rest call to {url} failed\n failure reason: Request timed out after {params.get("timeout")} seconds")
 
         raise Exception("The rest call to {url} failed\n"
                         "failure reason: {failure_reason}"

--- a/alooma/alooma.py
+++ b/alooma/alooma.py
@@ -120,7 +120,10 @@ class Client(object):
             return self.__send_request(func, url, True, **kwargs)
 
         if response.status_code == 504:
-            raise TimeoutError(f"The rest call to {url} failed\n failure reason: Request timed out after {params.get("timeout")} seconds")
+            raise TimeoutError("The rest call to {url} failed\n"
+                               "failure reason: Request timed out after {timeout} seconds"
+                               .format(url=response.url,
+                                       timeout=params.get("timeout")))
 
         raise Exception("The rest call to {url} failed\n"
                         "failure reason: {failure_reason}"

--- a/alooma/alooma.py
+++ b/alooma/alooma.py
@@ -119,6 +119,9 @@ class Client(object):
 
             return self.__send_request(func, url, True, **kwargs)
 
+        if response.status_code == 504:
+            raise TimeoutError(f"The rest call to {url} failed due to timing out after {params.get("timeout")}s")
+
         raise Exception("The rest call to {url} failed\n"
                         "failure reason: {failure_reason}"
                         "{failure_content}"


### PR DESCRIPTION
Raises a TimeoutError if response returns as a 504. This allows users to differentiate between flaky requests vs incorrect requests.